### PR TITLE
icons in main navigation bar

### DIFF
--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -5,6 +5,7 @@ import { MenuService } from '../shared/menu/menu.service';
 import { MenuID, MenuItemType } from '../shared/menu/initial-menus-state';
 import { TextMenuItemModel } from '../shared/menu/menu-item/models/text.model';
 import { LinkMenuItemModel } from '../shared/menu/menu-item/models/link.model';
+import { LinkIconMenuItemModel } from '../shared/menu/menu-item/models/linkicon.model';
 import { HostWindowService } from '../shared/host-window.service';
 import { BrowseService } from '../core/browse/browse.service';
 import { getFirstSucceededRemoteListPayload } from '../core/shared/operators';
@@ -145,10 +146,11 @@ export class NavbarComponent extends MenuComponent {
               active: false,
               visible: true,
               model: {
-                type: MenuItemType.LINK,
+                type: MenuItemType.LINKICON,
                 text: `menu.section.explore_${section.id}`,
+                icon: `menu.section.icon.explore_${section.id}`,
                 link: `/explore/${section.id}`
-              } as LinkMenuItemModel
+              } as LinkIconMenuItemModel
             };
             this.menuService.addSection(this.menuID, Object.assign(menuSection, {
               shouldPersistOnRouteChange: true

--- a/src/app/shared/menu/initial-menus-state.ts
+++ b/src/app/shared/menu/initial-menus-state.ts
@@ -12,7 +12,7 @@ export enum MenuID {
  * List of possible MenuItemTypes
  */
 export enum MenuItemType {
-  TEXT, LINK, ALTMETRIC, SEARCH, ONCLICK
+  TEXT, LINK, ALTMETRIC, SEARCH, ONCLICK, LINKICON
 }
 
 /**

--- a/src/app/shared/menu/menu-item/linkicon-menu-item.component.html
+++ b/src/app/shared/menu/menu-item/linkicon-menu-item.component.html
@@ -1,0 +1,10 @@
+<a class="nav-item nav-link"
+   [ngClass]="{ 'disabled': !hasLink }"
+   [attr.aria-disabled]="!hasLink"
+   [title]="item.text | translate"
+   [routerLink]="getRouterLink()"
+   (click)="$event.stopPropagation()"
+   (keyup.space)="navigate($event)"
+   (keyup.enter)="navigate($event)"
+   href="javascript:void(0);"
+><p *ngIf="hasIcon" class="exploreicon" [innerHTML]=icon></p> {{item.text | translate}} </a>

--- a/src/app/shared/menu/menu-item/linkicon-menu-item.component.scss
+++ b/src/app/shared/menu/menu-item/linkicon-menu-item.component.scss
@@ -1,0 +1,39 @@
+
+  .exploreicon {
+  font-size: 200%;
+  text-align:center;
+  }
+  
+  p.exploreicon {
+  margin-bottom: 4px;
+  }
+
+.exploreicon {
+    @media screen and (max-width: map-get($grid-breakpoints, md)) {
+	text-align:left;
+        float:left;
+        padding-right: 16px;
+        font-size: 133%; 
+
+        p.exploreicon {
+        margin-bottom: 1rem;
+  	}
+        
+	}
+}
+
+.nav-link {
+    @media screen and (max-width: map-get($grid-breakpoints, md)) {
+	vertical-align:middle;
+        font-size: 133%;    
+        border-bottom: 2px solid white;   
+	}
+}
+
+.nav-link > p {
+    @media screen and (max-width: map-get($grid-breakpoints, md)) {
+	margin-bottom:4px;
+	vertical-align:middle;
+	}
+}
+

--- a/src/app/shared/menu/menu-item/linkicon-menu-item.component.ts
+++ b/src/app/shared/menu/menu-item/linkicon-menu-item.component.ts
@@ -1,0 +1,62 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { LinkIconMenuItemModel } from './models/linkicon.model';
+import { MenuItemType } from '../initial-menus-state';
+import { rendersMenuItemForType } from '../menu-item.decorator';
+import { isNotEmpty } from '../../empty.util';
+import { environment } from '../../../../environments/environment';
+import { Router } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
+
+/**
+ * Component that renders a menu section of type LINK
+ */
+@Component({
+  selector: 'ds-linkicon-menu-item',
+    styleUrls: ['./linkicon-menu-item.component.scss'],
+  templateUrl: './linkicon-menu-item.component.html'
+})
+@rendersMenuItemForType(MenuItemType.LINKICON)
+export class LinkIconMenuItemComponent implements OnInit {
+  item: LinkIconMenuItemModel;
+  hasLink: boolean;
+  hasIcon: boolean;
+  icon: string;
+  constructor(
+    @Inject('itemModelProvider') item: LinkIconMenuItemModel,
+    private router: Router,
+    protected translateService: TranslateService,
+  ) {
+    this.item = item;
+  }
+
+  ngOnInit(): void {
+    this.hasLink = isNotEmpty(this.item.link);
+    if(this.item.icon){
+    let iconsymbol: string = this.translateService.instant(this.item.icon);
+    	if (iconsymbol === this.item.icon ) {
+    		this.hasIcon = false
+   	}else{
+   		this.icon = iconsymbol;
+   		this.hasIcon = true;
+   	}
+    }else{
+    	this.hasIcon = false;
+    }
+  }
+
+  getRouterLink() {
+    if (this.hasLink) {
+      return environment.ui.nameSpace + this.item.link;
+    }
+    return undefined;
+  }
+
+  navigate(event: any) {
+    event.preventDefault();
+    if (this.getRouterLink()) {
+      this.router.navigate([this.getRouterLink()]);
+    }
+    event.stopPropagation();
+  }
+
+}

--- a/src/app/shared/menu/menu-item/linkicon-menu-item.component.ts
+++ b/src/app/shared/menu/menu-item/linkicon-menu-item.component.ts
@@ -31,16 +31,16 @@ export class LinkIconMenuItemComponent implements OnInit {
 
   ngOnInit(): void {
     this.hasLink = isNotEmpty(this.item.link);
-    if(this.item.icon){
-    let iconsymbol: string = this.translateService.instant(this.item.icon);
-    	if (iconsymbol === this.item.icon ) {
-    		this.hasIcon = false
-   	}else{
-   		this.icon = iconsymbol;
-   		this.hasIcon = true;
-   	}
-    }else{
-    	this.hasIcon = false;
+    if (this.item.icon) {
+      const iconsymbol: string = this.translateService.instant(this.item.icon);
+      if (iconsymbol === this.item.icon ) {
+        this.hasIcon = false;
+      } else {
+        this.icon = iconsymbol;
+        this.hasIcon = true;
+      }
+    } else {
+      this.hasIcon = false;
     }
   }
 

--- a/src/app/shared/menu/menu-item/models/linkicon.model.ts
+++ b/src/app/shared/menu/menu-item/models/linkicon.model.ts
@@ -1,0 +1,13 @@
+import { MenuItemModel } from './menu-item.model';
+import { MenuItemType } from '../../initial-menus-state';
+
+/**
+ * Model representing an Link and Icon Menu Section
+ */
+export class LinkIconMenuItemModel implements MenuItemModel {
+  type = MenuItemType.LINKICON;
+  text: string;
+  icon?: string;
+  link: string;
+
+}

--- a/src/app/shared/menu/menu.module.ts
+++ b/src/app/shared/menu/menu.module.ts
@@ -4,6 +4,7 @@ import { NgModule } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { RouterModule } from '@angular/router';
 import { LinkMenuItemComponent } from './menu-item/link-menu-item.component';
+import { LinkIconMenuItemComponent } from './menu-item/linkicon-menu-item.component';
 import { TextMenuItemComponent } from './menu-item/text-menu-item.component';
 import { OnClickMenuItemComponent } from './menu-item/onclick-menu-item.component';
 import { CommonModule } from '@angular/common';
@@ -12,6 +13,7 @@ const COMPONENTS = [
   MenuSectionComponent,
   MenuComponent,
   LinkMenuItemComponent,
+  LinkIconMenuItemComponent,
   TextMenuItemComponent,
   OnClickMenuItemComponent
 ];

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -169,6 +169,7 @@ import { GenericItemPageFieldComponent } from '../item-page/simple/field-compone
 import { MetadataRepresentationListComponent } from '../item-page/simple/metadata-representation-list/metadata-representation-list.component';
 import { RelatedItemsComponent } from '../item-page/simple/related-items/related-items-component';
 import { LinkMenuItemComponent } from './menu/menu-item/link-menu-item.component';
+import { LinkIconMenuItemComponent } from './menu/menu-item/linkicon-menu-item.component';
 import { OnClickMenuItemComponent } from './menu/menu-item/onclick-menu-item.component';
 import { TextMenuItemComponent } from './menu/menu-item/text-menu-item.component';
 import { ItemExportComponent } from './item-export/item-export/item-export.component';
@@ -505,6 +506,7 @@ const ENTRY_COMPONENTS = [
   CollectionSidebarSearchListElementComponent,
   CommunitySidebarSearchListElementComponent,
   LinkMenuItemComponent,
+  LinkIconMenuItemComponent,
   OnClickMenuItemComponent,
   TextMenuItemComponent,
   ScopeSelectorModalComponent,

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3244,13 +3244,20 @@
 
   "menu.section.explore_researchoutputs": "Research Outputs",
 
+  "menu.section.icon.explore_researchoutputs": "<span class=\"fa fa-file-alt\"></span>",
+
   "menu.section.explore_researcherprofiles": "People",
+
+  "menu.section.icon.explore_researcherprofiles": "<span class=\"fa fa-users\"></span>",
 
   "menu.section.explore_orgunits": "Organizations",
 
   "menu.section.explore_fundings": "Projects",
 
   "menu.section.explore_fundings_and_projects": "Projects",
+
+  "menu.section.icon.explore_fundings_and_projects": "<span class=\"fa fa-cogs\"></span>",
+
 
   "menu.section.communities_and_collections": "Communities & Collections",
 


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #[issue-number]
* Requires DSpace/DSpace#[pr-number] (if a REST API PR is required to test this)

## Description

Working state of our implementation of navigation icons as presented and discussed at the Cris working group meeting 2022-04-05 (https://docs.google.com/document/d/1NJvUtDwKymY1hhxtcT_wjQvzx4pZlJcf0xICz5LRsq0)
Still a draft, because tests are missing.

Connected to open backend:



![Screenshot 2022-03-22 at 10-52-39 DSpace Cris Angular Home](https://user-images.githubusercontent.com/33422716/161750522-8625291b-f1fa-4599-b88a-feec4c12f2ab.png)
86-3796450a-ac4b-46e2-bbf0-8a854d3b984f.png)

![Screenshot 2022-03-22 at 10-56-57 DSpace Cris Angular Home](https://user-images.githubusercontent.com/33422716/161751587-ae156c52-0f0d-4a99-8948-f253256688a4.png)

## Instructions for Reviewers

List of changes in this PR:
- own component for link with icon (mainly using logic from `LinkMenuItemModel`)
- explore-section-navigation uses new component instead of lint component
- icons definable in Messages
- If no i18n key is provided, only the title is shown.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [ ] My PR doesn't introduce circular dependencies
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
