### PR TITLE
Multilingual entity titles

### DIFF
--- a/src/app/core/breadcrumbs/dso-name.service.ts
+++ b/src/app/core/breadcrumbs/dso-name.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { hasValue, isEmpty } from '../../shared/empty.util';
 import { DSpaceObject } from '../shared/dspace-object.model';
+import { MetadataValue } from '../shared/metadata.models';
 import { TranslateService } from '@ngx-translate/core';
 
 /**
@@ -36,14 +37,36 @@ export class DSONameService {
       }
     },
     OrgUnit: (dso: DSpaceObject): string => {
-      return dso.firstMetadataValue('organization.legalName') || dso.firstMetadataValue('dc.title');
+      return dso.firstMetadataValue('organization.legalName') || this.multilingualTitle(dso, 'dc.title') || dso.firstMetadataValue('dc.title');
     },
     Default: (dso: DSpaceObject): string => {
+        
       // If object doesn't have dc.title metadata use name property
-      return dso.firstMetadataValue('dc.title') || dso.name || this.translateService.instant('dso.name.untitled');
+      return this.multilingualTitle(dso, 'dc.title') || dso.firstMetadataValue('dc.title') || dso.name || this.translateService.instant('dso.name.untitled');
     }
   };
-
+  /*
+  * returns the first matching entry in the current locale or the first value.
+  */
+  multilingualTitle(dso: DSpaceObject, field: string): string {
+        let locale = this.translateService.currentLang;
+            let mvs: MetadataValue[] = dso.allMetadata(field);
+	    //Only one entry, return first value;
+	    if(mvs.length == 1 && mvs[0] != undefined) return mvs[0].value;
+	    for(let mv of mvs){
+		    if(mv.language != undefined && mv.language != "" && mv.language.indexOf(locale) == 0){
+	    		//return matching entry
+			return mv.value;
+		    }
+	    }
+        //No matches for language, return first value;
+	if(mvs[0] != undefined){
+	        return mvs[0].value;
+	}else{
+		return undefined;
+	}
+  }
+  
   /**
    * Get the name for the given {@link DSpaceObject}
    *

--- a/src/app/core/breadcrumbs/dso-name.service.ts
+++ b/src/app/core/breadcrumbs/dso-name.service.ts
@@ -40,7 +40,6 @@ export class DSONameService {
       return dso.firstMetadataValue('organization.legalName') || this.multilingualTitle(dso, 'dc.title') || dso.firstMetadataValue('dc.title');
     },
     Default: (dso: DSpaceObject): string => {
-        
       // If object doesn't have dc.title metadata use name property
       return this.multilingualTitle(dso, 'dc.title') || dso.firstMetadataValue('dc.title') || dso.name || this.translateService.instant('dso.name.untitled');
     }
@@ -49,24 +48,24 @@ export class DSONameService {
   * returns the first matching entry in the current locale or the first value.
   */
   multilingualTitle(dso: DSpaceObject, field: string): string {
-        let locale = this.translateService.currentLang;
-            let mvs: MetadataValue[] = dso.allMetadata(field);
-	    //Only one entry, return first value;
-	    if(mvs.length == 1 && mvs[0] != undefined) return mvs[0].value;
-	    for(let mv of mvs){
-		    if(mv.language != undefined && mv.language != "" && mv.language.indexOf(locale) == 0){
-	    		//return matching entry
-			return mv.value;
-		    }
-	    }
-        //No matches for language, return first value;
-	if(mvs[0] != undefined){
-	        return mvs[0].value;
-	}else{
-		return undefined;
-	}
+    const locale = this.translateService.currentLang;
+    const mvs: MetadataValue[] = dso.allMetadata(field);
+            // Only one entry, return first value;
+      // if (mvs.length === 1 && mvs[0] !== undefined) return mvs[0].value;
+    for (const mv of mvs) {
+      if (mv.language !== undefined && mv.language !== '' && mv.language.indexOf(locale) === 0) {
+        // return matching entry
+        return mv.value;
+      }
+    }
+  // No matches for language, return first value;
+    if (mvs[0] !== undefined) {
+      return mvs[0].value;
+    } else {
+      return undefined;
+    }
   }
-  
+
   /**
    * Get the name for the given {@link DSpaceObject}
    *

--- a/src/app/core/breadcrumbs/dso-name.service.ts
+++ b/src/app/core/breadcrumbs/dso-name.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { hasValue, isEmpty } from '../../shared/empty.util';
+import { hasValue, isEmpty, isNotEmpty } from '../../shared/empty.util';
 import { DSpaceObject } from '../shared/dspace-object.model';
 import { MetadataValue } from '../shared/metadata.models';
 import { TranslateService } from '@ngx-translate/core';
@@ -58,7 +58,13 @@ export class DSONameService {
         return mv.value;
       }
     }
-  // No matches for language, return first value;
+    const defaultlanguage = this.translateService.defaultLang;
+    for (const mv of mvs) {
+      if (isNotEmpty(mv.language) && mv.language.indexOf(defaultlanguage) === 0) {
+        return mv.value;
+      }
+    }
+  // No matches for language, return first value
     if (mvs[0] !== undefined) {
       return mvs[0].value;
     } else {

--- a/src/app/cris-layout/cris-layout-matrix/cris-layout-box-container/boxes/metadata/rendering-types/metadata-box.decorator.ts
+++ b/src/app/cris-layout/cris-layout-matrix/cris-layout-box-container/boxes/metadata/rendering-types/metadata-box.decorator.ts
@@ -16,6 +16,7 @@ export enum FieldRenderingType {
   ORCID = 'ORCID',
   TAG = 'TAG',
   VALUEPAIR = 'VALUEPAIR',
+  TEXTMULTILINGUAL = 'TEXTMULTILINGUAL',
 }
 
 const fieldType = new Map();

--- a/src/app/cris-layout/cris-layout-matrix/cris-layout-box-container/boxes/metadata/rendering-types/textmultilingual/textmultilingual.component.html
+++ b/src/app/cris-layout/cris-layout-matrix/cris-layout-box-container/boxes/metadata/rendering-types/textmultilingual/textmultilingual.component.html
@@ -1,0 +1,5 @@
+<div [class]="field.styleValue">
+    <span class="text-value">
+{{getField}}
+    </span>
+</div>

--- a/src/app/cris-layout/cris-layout-matrix/cris-layout-box-container/boxes/metadata/rendering-types/textmultilingual/textmultilingual.component.ts
+++ b/src/app/cris-layout/cris-layout-matrix/cris-layout-box-container/boxes/metadata/rendering-types/textmultilingual/textmultilingual.component.ts
@@ -21,25 +21,25 @@ export class TextMultilingualComponent extends RenderingTypeStructuredModelCompo
 
 
   get getField(): string {
-    let locale = this.translateService.currentLang;
-    let mvs: MetadataValue[] = this.item.allMetadata(this.field.metadata);
-    //Only one entry, return first value;
-    if(mvs.length == 1){
-	return mvs[0].value;
+    const locale = this.translateService.currentLang;
+    const mvs: MetadataValue[] = this.item.allMetadata(this.field.metadata);
+    // Only one entry, return first value;
+    if (mvs.length === 1) {
+      return mvs[0].value;
     }
-    for(let mv of mvs){
-	    if(isNotEmpty(mv.language) && mv.language.indexOf(locale) == 0){
-		return mv.value;
-	    }
+    for (const mv of mvs) {
+      if (isNotEmpty(mv.language) && mv.language.indexOf(locale) === 0) {
+        return mv.value;
+      }
     }
-    //return matching entry in default language
-    let defaultlanguage = this.translateService.defaultLang;
-        for(let mv of mvs){
-	    if(isNotEmpty(mv.language) && mv.language.indexOf(defaultlanguage) == 0){
-		return mv.value;
-	    }
-    	}
-        //No matches for default language, return first value;
+    // return matching entry in default language
+    const defaultlanguage = this.translateService.defaultLang;
+        for (const mv of mvs) {
+          if (isNotEmpty(mv.language) && mv.language.indexOf(defaultlanguage) === 0) {
+            return mv.value;
+          }
+        }
+        // No matches for default language, return first value;
         return mvs[0].value;
   }
 }

--- a/src/app/cris-layout/cris-layout-matrix/cris-layout-box-container/boxes/metadata/rendering-types/textmultilingual/textmultilingual.component.ts
+++ b/src/app/cris-layout/cris-layout-matrix/cris-layout-box-container/boxes/metadata/rendering-types/textmultilingual/textmultilingual.component.ts
@@ -1,0 +1,45 @@
+import { Component, Inject } from '@angular/core';
+
+import { FieldRenderingType, MetadataBoxFieldRendering } from '../metadata-box.decorator';
+import { RenderingTypeStructuredModelComponent } from '../rendering-type-structured.model';
+import { MetadataValue } from '../../../../../../../core/shared/metadata.models';
+import { LayoutField } from '../../../../../../../core/layout/models/box.model';
+import { Item } from '../../../../../../../core/shared/item.model';
+import { isNotEmpty } from '../../../../../../../shared/empty.util';
+import { TranslateService } from '@ngx-translate/core';
+/**
+ * This component renders the text metadata fields. It shows the first value in the current language and otherwise the value.
+ */
+@Component({
+  // tslint:disable-next-line: component-selector
+  selector: 'span[ds-text-multilingual]',
+  templateUrl: './textmultilingual.component.html',
+  styleUrls: ['./textmultilingual.component.scss']
+})
+@MetadataBoxFieldRendering(FieldRenderingType.TEXTMULTILINGUAL, true)
+export class TextMultilingualComponent extends RenderingTypeStructuredModelComponent {
+
+
+  get getField(): string {
+    let locale = this.translateService.currentLang;
+    let mvs: MetadataValue[] = this.item.allMetadata(this.field.metadata);
+    //Only one entry, return first value;
+    if(mvs.length == 1){
+	return mvs[0].value;
+    }
+    for(let mv of mvs){
+	    if(isNotEmpty(mv.language) && mv.language.indexOf(locale) == 0){
+		return mv.value;
+	    }
+    }
+    //return matching entry in default language
+    let defaultlanguage = this.translateService.defaultLang;
+        for(let mv of mvs){
+	    if(isNotEmpty(mv.language) && mv.language.indexOf(defaultlanguage) == 0){
+		return mv.value;
+	    }
+    	}
+        //No matches for default language, return first value;
+        return mvs[0].value;
+  }
+}

--- a/src/app/cris-layout/cris-layout.module.ts
+++ b/src/app/cris-layout/cris-layout.module.ts
@@ -18,6 +18,7 @@ import { CrisLayoutBoxContainerComponent } from './cris-layout-matrix/cris-layou
 import { RowComponent } from './cris-layout-matrix/cris-layout-box-container/boxes/metadata/row/row.component';
 import { CrisLayoutMetadataBoxComponent } from './cris-layout-matrix/cris-layout-box-container/boxes/metadata/cris-layout-metadata-box.component';
 import { TextComponent } from './cris-layout-matrix/cris-layout-box-container/boxes/metadata/rendering-types/text/text.component';
+import { TextMultilingualComponent } from './cris-layout-matrix/cris-layout-box-container/boxes/metadata/rendering-types/textmultilingual/textmultilingual.component';
 import { HeadingComponent } from './cris-layout-matrix/cris-layout-box-container/boxes/metadata/rendering-types/heading/heading.component';
 import { CrisLayoutRelationBoxComponent } from './cris-layout-matrix/cris-layout-box-container/boxes/relation/cris-layout-relation-box.component';
 import { MyDSpacePageModule } from '../my-dspace-page/my-dspace-page.module';
@@ -53,6 +54,7 @@ const ENTRY_COMPONENTS = [
   CrisLayoutHorizontalComponent,
   CrisLayoutMetadataBoxComponent,
   TextComponent,
+  TextMultilingualComponent,
   HeadingComponent,
   CrisLayoutRelationBoxComponent,
   CrisLayoutIIIFViewerBoxComponent,


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #[issue-number]
* Requires DSpace/DSpace#[pr-number] (if a REST API PR is required to test this)

## Description

Working state of our implementation of multilingualism as presented and discussed at the Cris working group meeting 2022-04-05 (https://docs.google.com/document/d/1NJvUtDwKymY1hhxtcT_wjQvzx4pZlJcf0xICz5LRsq0)
Not sure, if multilingualism is the correct term in this context to distinguish it from the i18n translation.
Still a draft, because tests are missing.

## Instructions for Reviewers

List of changes in this PR:
- dso-name-service: changed behaviour how the displaying title is being determined
  - get the first dc.title starting with same language as the current UI locale
  - get the first dc.title starting with the first language as the default UI locale
  - get the first dc.title in any language
- component textmultilingual for cris layout: similiar behaviour for the single metadatafield being shown
  - get the first metadatafield value starting with same language as the current UI locale
  - get the first metadatafield value starting with the first language as the default UI locale
  - get the first metadatafield value in any language

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

- create entities with dc.title in several languages
- add dc.title metadata with `textmultilingual` rendering
For Example given (place of Metadata should matter):
dc.title::it_IT  
dc.title::en_EN  
dc.title::de_DE  

| locale | defaultlocale | shown value |
| ------------- | ------------- | ------------- |
| it  | en   | dc.title::it_IT  |
| de  | en | dc.title::de _DE  |
| ru | en   | dc.title::en_EN  |

dc.title::it_IT   
dc.title::en_EN  
dc.title  
| locale | defaultlocale | shown value |
| ------------- | ------------- | ------------- |
| it  | en | dc.title::it_IT  |
| ru | en   | dc.title::en_EN  |
| de | en   | dc.title::en_EN  |

dc.title  
dc.title ::it_IT 
| locale | defaultlocale | shown value |
| ------------- | ------------- | ------------- |
| it  | en | dc.title::it_IT |
| ru | en   | dc.title  |
| en | en   | dc.title  |


Effects / Use Cases:
- Display of general Search-Result-Lists (and possible other benefits like the breadcrumb, page title etc...)
- locale de: (first result has dc.title in de_DE and en_EN)
![Screensho 2022-03-22 at 11-28-30 DSpace Cris Angular DSpace Angular Suche](https://user-images.githubusercontent.com/33422716/161761176-18f42527-cdaf-426c-9f65-4e4cb8065a25.png)
- locale en:
![Screenshot 2022-03-22 at 11-28-18 DSpace Cris Angular Search](https://user-images.githubusercontent.com/33422716/161761194-2ac666c9-0edd-44e4-9cd6-7fe385099c8b.png)

- Display of Cris Layout (f.e. leading tab)
- locale de:
![Screenshot 2022-03-22 at 11-50-28 Videobasierte Validitätsanalysen und Zusammenhänge zwischen Maßen früher Kompetenzentwicklung und Lernumwelten (VIVA)](https://user-images.githubusercontent.com/33422716/161760944-24a7f553-fe3e-4883-a751-546ae673705e.png)
- locale en:
![Screenshot 2022-03-22 at 11-50-13 Video-based validity analyses of measures of early childhood competencies and home learning environment (ViVA)](https://user-images.githubusercontent.com/33422716/161761012-c8b27540-06b3-4745-912e-816e9fd90edc.png)


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [ ] My PR doesn't introduce circular dependencies
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
