### PR TITLE
fix orcid badge not shown

### DIFF
--- a/src/app/cris-layout/cris-layout-matrix/cris-layout-box-container/boxes/metadata/rendering-types/orcid/orcid.component.spec.ts
+++ b/src/app/cris-layout/cris-layout-matrix/cris-layout-box-container/boxes/metadata/rendering-types/orcid/orcid.component.spec.ts
@@ -24,7 +24,7 @@ export const testItem: Item = Object.assign(new Item(), {
         value: '0000-0001-8918-3592'
       }
     ],
-    'cris.orcid.authenticated': [
+    'dspace.orcid.authenticated': [
       {
         language: null,
         value: 'authenticated'
@@ -149,7 +149,7 @@ describe('OrcidComponent', () => {
       type: 'item',
       metadata: {
         'person.identifier.orcid': [metadataValue],
-        'cris.orcid.authenticated': [
+        'dspace.orcid.authenticated': [
           {
             language: null,
             value: 'authenticated'

--- a/src/app/cris-layout/cris-layout-matrix/cris-layout-box-container/boxes/metadata/rendering-types/orcid/orcid.component.ts
+++ b/src/app/cris-layout/cris-layout-matrix/cris-layout-box-container/boxes/metadata/rendering-types/orcid/orcid.component.ts
@@ -50,7 +50,7 @@ export class OrcidComponent extends RenderingTypeValueModelComponent implements 
   }
 
   public hasOrcidBadge(): boolean {
-    return this.item.hasMetadata('cris.orcid.authenticated');
+    return this.item.hasMetadata('dspace.orcid.authenticated');
   }
 
 }

--- a/src/app/shared/metadata-link-view/metadata-link-view.component.spec.ts
+++ b/src/app/shared/metadata-link-view/metadata-link-view.component.spec.ts
@@ -51,7 +51,7 @@ describe('MetadataLinkViewComponent', () => {
           value: '0000-0001-8918-3592'
         })
       ],
-      'cris.orcid.authenticated': [
+      'dspace.orcid.authenticated': [
         Object.assign(new MetadataValue(), {
           language: null,
           value: 'authenticated'

--- a/src/app/shared/metadata-link-view/metadata-link-view.component.ts
+++ b/src/app/shared/metadata-link-view/metadata-link-view.component.ts
@@ -116,7 +116,7 @@ export class MetadataLinkViewComponent implements OnInit {
    * @param referencedItem Item of the metadata being shown
    */
   getOrcid(referencedItem: Item): string {
-    if (referencedItem.hasMetadata('cris.orcid.authenticated')) {
+    if (referencedItem.hasMetadata('dspace.orcid.authenticated')) {
       return referencedItem.firstMetadataValue('person.identifier.orcid');
     }
     return null;


### PR DESCRIPTION
## References

## Description
The orcid badge is not shown, after the last database migrations from Release 2022.02.00 are applied.

## Instructions for Reviewers

List of changes in this PR:

* replace cris.orcid.authenticated with dspace.orcid.authenticated in places where the orcid badge is shown.
* rewrite component test to new field. yarn run test passes.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 
- Migrate to Release 2022.02.00 and 
- investigate some default search result or orcid rendering with person/author known having some orcid.
- possible candidates for persons can be identicated by the search query `cris.orcid.authenticated:* and person.identifier.orcid:*`or `dspace.orcid.authenticated:* and person.identifier.orcid:*` (before/after migration)
- By today (2022-10-12) not replicable on the public demo-system https://dspacecris7.4science.cloud/ - migration seems not to be run by now.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [ ] My PR doesn't introduce circular dependencies
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
