### PR TITLE
[CST-7216] Imported UploadModule in AdminModule to fix build error

### DIFF
--- a/src/app/admin/admin-import-batch-page/batch-import-page.component.html
+++ b/src/app/admin/admin-import-batch-page/batch-import-page.component.html
@@ -20,10 +20,15 @@
     </small>
   </div>
 
-  <ui-switch [checkedLabel]="'admin.metadata-import.page.toggle.upload' | translate"
+  <ui-switch color="#ebebeb"
+             [checkedLabel]="'admin.metadata-import.page.toggle.upload' | translate"
              [uncheckedLabel]="'admin.metadata-import.page.toggle.url' | translate"
              [checked]="isUpload"
              (change)="toggleUpload()" ></ui-switch>
+  <small class="form-text text-muted">
+    {{'admin.batch-import.page.toggle.help' | translate}}
+  </small>
+  
 
   <ds-file-dropzone-no-uploader
     *ngIf="isUpload"

--- a/src/app/admin/admin-import-batch-page/batch-import-page.component.html
+++ b/src/app/admin/admin-import-batch-page/batch-import-page.component.html
@@ -20,11 +20,23 @@
     </small>
   </div>
 
+  <ui-switch [checkedLabel]="'admin.metadata-import.page.toggle.upload' | translate"
+             [uncheckedLabel]="'admin.metadata-import.page.toggle.url' | translate"
+             [checked]="isUpload"
+             (change)="toggleUpload()" ></ui-switch>
+
   <ds-file-dropzone-no-uploader
+    *ngIf="isUpload"
+    data-test="file-dropzone"
     (onFileAdded)="setFile($event)"
     [dropMessageLabel]="'admin.batch-import.page.dropMsg'"
     [dropMessageLabelReplacement]="'admin.batch-import.page.dropMsgReplace'">
   </ds-file-dropzone-no-uploader>
+
+  <div class="form-group mt-2" *ngIf="!isUpload">
+    <input class="form-control" type="text" placeholder="{{'admin.metadata-import.page.urlMsg' | translate}}"
+           data-test="file-url-input" [(ngModel)]="fileURL">
+  </div>
 
   <div class="space-children-mr">
     <button class="btn btn-secondary" id="backButton"

--- a/src/app/admin/admin-import-batch-page/batch-import-page.component.spec.ts
+++ b/src/app/admin/admin-import-batch-page/batch-import-page.component.spec.ts
@@ -86,8 +86,16 @@ describe('BatchImportPageComponent', () => {
     let fileMock: File;
 
     beforeEach(() => {
+      component.isUpload = true;
       fileMock = new File([''], 'filename.zip', { type: 'application/zip' });
       component.setFile(fileMock);
+    });
+
+    it('should show the file dropzone', () => {
+      const fileDropzone = fixture.debugElement.query(By.css('[data-test="file-dropzone"]'));
+      const fileUrlInput = fixture.debugElement.query(By.css('[data-test="file-url-input"]'));
+      expect(fileDropzone).toBeTruthy();
+      expect(fileUrlInput).toBeFalsy();
     });
 
     describe('if proceed button is pressed without validate only', () => {
@@ -99,9 +107,9 @@ describe('BatchImportPageComponent', () => {
       }));
       it('metadata-import script is invoked with --zip fileName and the mockFile', () => {
         const parameterValues: ProcessParameter[] = [
-          Object.assign(new ProcessParameter(), { name: '--zip', value: 'filename.zip' }),
+          Object.assign(new ProcessParameter(), { name: '--add' }),
+          Object.assign(new ProcessParameter(), { name: '--zip', value: 'filename.zip' })
         ];
-        parameterValues.push(Object.assign(new ProcessParameter(), { name: '--add' }));
         expect(scriptService.invoke).toHaveBeenCalledWith(BATCH_IMPORT_SCRIPT_NAME, parameterValues, [fileMock]);
       });
       it('success notification is shown', () => {
@@ -121,11 +129,84 @@ describe('BatchImportPageComponent', () => {
       }));
       it('metadata-import script is invoked with --zip fileName and the mockFile and -v validate-only', () => {
         const parameterValues: ProcessParameter[] = [
-          Object.assign(new ProcessParameter(), { name: '--zip', value: 'filename.zip' }),
           Object.assign(new ProcessParameter(), { name: '--add' }),
+          Object.assign(new ProcessParameter(), { name: '--zip', value: 'filename.zip' }),
           Object.assign(new ProcessParameter(), { name: '-v', value: true }),
         ];
         expect(scriptService.invoke).toHaveBeenCalledWith(BATCH_IMPORT_SCRIPT_NAME, parameterValues, [fileMock]);
+      });
+      it('success notification is shown', () => {
+        expect(notificationService.success).toHaveBeenCalled();
+      });
+      it('redirected to process page', () => {
+        expect(router.navigateByUrl).toHaveBeenCalledWith('/processes/46');
+      });
+    });
+
+    describe('if proceed is pressed; but script invoke fails', () => {
+      beforeEach(fakeAsync(() => {
+        jasmine.getEnv().allowRespy(true);
+        spyOn(scriptService, 'invoke').and.returnValue(createFailedRemoteDataObject$('Error', 500));
+        const proceed = fixture.debugElement.query(By.css('#proceedButton')).nativeElement;
+        proceed.click();
+        fixture.detectChanges();
+      }));
+      it('error notification is shown', () => {
+        expect(notificationService.error).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('if url is set', () => {
+    beforeEach(fakeAsync(() => {
+      component.isUpload = false;
+      component.fileURL = 'example.fileURL.com';
+      fixture.detectChanges();
+    }));
+
+    it('should show the file url input', () => {
+      const fileDropzone = fixture.debugElement.query(By.css('[data-test="file-dropzone"]'));
+      const fileUrlInput = fixture.debugElement.query(By.css('[data-test="file-url-input"]'));
+      expect(fileDropzone).toBeFalsy();
+      expect(fileUrlInput).toBeTruthy();
+    });
+
+    describe('if proceed button is pressed without validate only', () => {
+      beforeEach(fakeAsync(() => {
+        component.validateOnly = false;
+        const proceed = fixture.debugElement.query(By.css('#proceedButton')).nativeElement;
+        proceed.click();
+        fixture.detectChanges();
+      }));
+      it('metadata-import script is invoked with --u and the file url', () => {
+        const parameterValues: ProcessParameter[] = [
+          Object.assign(new ProcessParameter(), { name: '--add' }),
+          Object.assign(new ProcessParameter(), { name: '--u', value: 'example.fileURL.com' })
+        ];
+        expect(scriptService.invoke).toHaveBeenCalledWith(BATCH_IMPORT_SCRIPT_NAME, parameterValues, [null]);
+      });
+      it('success notification is shown', () => {
+        expect(notificationService.success).toHaveBeenCalled();
+      });
+      it('redirected to process page', () => {
+        expect(router.navigateByUrl).toHaveBeenCalledWith('/processes/46');
+      });
+    });
+
+    describe('if proceed button is pressed with validate only', () => {
+      beforeEach(fakeAsync(() => {
+        component.validateOnly = true;
+        const proceed = fixture.debugElement.query(By.css('#proceedButton')).nativeElement;
+        proceed.click();
+        fixture.detectChanges();
+      }));
+      it('metadata-import script is invoked with --u and the file url and -v validate-only', () => {
+        const parameterValues: ProcessParameter[] = [
+          Object.assign(new ProcessParameter(), { name: '--add' }),
+          Object.assign(new ProcessParameter(), { name: '--u', value: 'example.fileURL.com' }),
+          Object.assign(new ProcessParameter(), { name: '-v', value: true }),
+        ];
+        expect(scriptService.invoke).toHaveBeenCalledWith(BATCH_IMPORT_SCRIPT_NAME, parameterValues, [null]);
       });
       it('success notification is shown', () => {
         expect(notificationService.success).toHaveBeenCalled();

--- a/src/app/admin/admin-import-batch-page/batch-import-page.component.spec.ts
+++ b/src/app/admin/admin-import-batch-page/batch-import-page.component.spec.ts
@@ -178,10 +178,10 @@ describe('BatchImportPageComponent', () => {
         proceed.click();
         fixture.detectChanges();
       }));
-      it('metadata-import script is invoked with --u and the file url', () => {
+      it('metadata-import script is invoked with --url and the file url', () => {
         const parameterValues: ProcessParameter[] = [
           Object.assign(new ProcessParameter(), { name: '--add' }),
-          Object.assign(new ProcessParameter(), { name: '--u', value: 'example.fileURL.com' })
+          Object.assign(new ProcessParameter(), { name: '--url', value: 'example.fileURL.com' })
         ];
         expect(scriptService.invoke).toHaveBeenCalledWith(BATCH_IMPORT_SCRIPT_NAME, parameterValues, [null]);
       });
@@ -200,10 +200,10 @@ describe('BatchImportPageComponent', () => {
         proceed.click();
         fixture.detectChanges();
       }));
-      it('metadata-import script is invoked with --u and the file url and -v validate-only', () => {
+      it('metadata-import script is invoked with --url and the file url and -v validate-only', () => {
         const parameterValues: ProcessParameter[] = [
           Object.assign(new ProcessParameter(), { name: '--add' }),
-          Object.assign(new ProcessParameter(), { name: '--u', value: 'example.fileURL.com' }),
+          Object.assign(new ProcessParameter(), { name: '--url', value: 'example.fileURL.com' }),
           Object.assign(new ProcessParameter(), { name: '-v', value: true }),
         ];
         expect(scriptService.invoke).toHaveBeenCalledWith(BATCH_IMPORT_SCRIPT_NAME, parameterValues, [null]);

--- a/src/app/admin/admin-import-batch-page/batch-import-page.component.ts
+++ b/src/app/admin/admin-import-batch-page/batch-import-page.component.ts
@@ -84,7 +84,11 @@ export class BatchImportPageComponent {
    */
   public importMetadata() {
     if (this.fileObject == null && isEmpty(this.fileURL)) {
-      this.notificationsService.error(this.translate.get('admin.metadata-import.page.error.addFile'));
+      if (this.isUpload) {
+        this.notificationsService.error(this.translate.get('admin.metadata-import.page.error.addFile'));
+      } else {
+        this.notificationsService.error(this.translate.get('admin.metadata-import.page.error.addFileUrl'));
+      }
     } else {
       const parameterValues: ProcessParameter[] = [
         Object.assign(new ProcessParameter(), { name: '--add' })
@@ -93,7 +97,7 @@ export class BatchImportPageComponent {
         parameterValues.push(Object.assign(new ProcessParameter(), { name: '--zip', value: this.fileObject.name }));
       } else {
         this.fileObject = null;
-        parameterValues.push(Object.assign(new ProcessParameter(), { name: '--u', value: this.fileURL }));
+        parameterValues.push(Object.assign(new ProcessParameter(), { name: '--url', value: this.fileURL }));
       }
       if (this.dso) {
         parameterValues.push(Object.assign(new ProcessParameter(), { name: '--collection', value: this.dso.uuid }));

--- a/src/app/admin/admin-import-batch-page/batch-import-page.component.ts
+++ b/src/app/admin/admin-import-batch-page/batch-import-page.component.ts
@@ -8,7 +8,7 @@ import { ProcessParameter } from '../../process-page/processes/process-parameter
 import { getFirstCompletedRemoteData } from '../../core/shared/operators';
 import { RemoteData } from '../../core/data/remote-data';
 import { Process } from '../../process-page/processes/process.model';
-import { isNotEmpty } from '../../shared/empty.util';
+import { isEmpty, isNotEmpty } from '../../shared/empty.util';
 import { getProcessDetailRoute } from '../../process-page/process-page-routing.paths';
 import {
   ImportBatchSelectorComponent
@@ -32,10 +32,21 @@ export class BatchImportPageComponent {
    * The validate only flag
    */
   validateOnly = true;
+
   /**
    * dso object for community or collection
    */
   dso: DSpaceObject = null;
+
+  /**
+   * The flag between upload and url
+   */
+  isUpload = true;
+
+  /**
+   * File URL when flag is for url
+   */
+  fileURL: string;
 
   public constructor(private location: Location,
                      protected translate: TranslateService,
@@ -72,13 +83,18 @@ export class BatchImportPageComponent {
    * Starts import-metadata script with --zip fileName (and the selected file)
    */
   public importMetadata() {
-    if (this.fileObject == null) {
+    if (this.fileObject == null && isEmpty(this.fileURL)) {
       this.notificationsService.error(this.translate.get('admin.metadata-import.page.error.addFile'));
     } else {
       const parameterValues: ProcessParameter[] = [
-        Object.assign(new ProcessParameter(), { name: '--zip', value: this.fileObject.name }),
         Object.assign(new ProcessParameter(), { name: '--add' })
       ];
+      if (this.isUpload) {
+        parameterValues.push(Object.assign(new ProcessParameter(), { name: '--zip', value: this.fileObject.name }));
+      } else {
+        this.fileObject = null;
+        parameterValues.push(Object.assign(new ProcessParameter(), { name: '--u', value: this.fileURL }));
+      }
       if (this.dso) {
         parameterValues.push(Object.assign(new ProcessParameter(), { name: '--collection', value: this.dso.uuid }));
       }
@@ -120,5 +136,12 @@ export class BatchImportPageComponent {
    */
   removeDspaceObject(): void {
     this.dso = null;
+  }
+
+  /**
+   * toggle the flag between upload and url
+   */
+  toggleUpload() {
+    this.isUpload = !this.isUpload;
   }
 }

--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -10,7 +10,7 @@ import { AdminSearchModule } from './admin-search-page/admin-search.module';
 import { AdminSidebarSectionComponent } from './admin-sidebar/admin-sidebar-section/admin-sidebar-section.component';
 import { ExpandableAdminSidebarSectionComponent } from './admin-sidebar/expandable-admin-sidebar-section/expandable-admin-sidebar-section.component';
 import { BatchImportPageComponent } from './admin-import-batch-page/batch-import-page.component';
-import { UploadModule } from '../shared/upload/upload.module';
+import { UiSwitchModule } from 'ngx-ui-switch';
 
 const ENTRY_COMPONENTS = [
   // put only entry components that use custom decorator
@@ -27,7 +27,7 @@ const ENTRY_COMPONENTS = [
     AdminSearchModule.withEntryComponents(),
     AdminWorkflowModuleModule.withEntryComponents(),
     SharedModule,
-    UploadModule,
+    UiSwitchModule
   ],
   declarations: [
     AdminCurationTasksComponent,

--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -11,6 +11,7 @@ import { AdminSidebarSectionComponent } from './admin-sidebar/admin-sidebar-sect
 import { ExpandableAdminSidebarSectionComponent } from './admin-sidebar/expandable-admin-sidebar-section/expandable-admin-sidebar-section.component';
 import { BatchImportPageComponent } from './admin-import-batch-page/batch-import-page.component';
 import { UiSwitchModule } from 'ngx-ui-switch';
+import { UploadModule } from '../shared/upload/upload.module';
 
 const ENTRY_COMPONENTS = [
   // put only entry components that use custom decorator
@@ -27,7 +28,8 @@ const ENTRY_COMPONENTS = [
     AdminSearchModule.withEntryComponents(),
     AdminWorkflowModuleModule.withEntryComponents(),
     SharedModule,
-    UiSwitchModule
+    UiSwitchModule,
+    UploadModule,
   ],
   declarations: [
     AdminCurationTasksComponent,

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -586,6 +586,12 @@
 
   "admin.batch-import.page.error.addFile": "Select Zip file first!",
 
+  "admin.metadata-import.page.toggle.upload": "Upload",
+
+  "admin.metadata-import.page.toggle.url": "URL",
+
+  "admin.metadata-import.page.urlMsg": "Insert the batch ZIP url to import",
+
   "admin.metadata-import.page.validateOnly": "Validate Only",
 
   "admin.metadata-import.page.validateOnly.hint": "When selected, the uploaded CSV will be validated. You will receive a report of detected changes, but no changes will be saved.",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -568,6 +568,8 @@
 
   "admin.batch-import.page.help": "Select the Collection to import into. Then, drop or browse to a Simple Archive Format (SAF) zip file that includes the Items to import",
 
+  "admin.batch-import.page.toggle.help": "It is possible to perform import either with file upload or via URL, use above toggle to set the input source",
+
   "admin.metadata-import.page.dropMsg": "Drop a metadata CSV to import",
 
   "admin.batch-import.page.dropMsg": "Drop a batch ZIP to import",
@@ -583,6 +585,8 @@
   "admin.metadata-import.page.button.select-collection": "Select Collection",
 
   "admin.metadata-import.page.error.addFile": "Select file first!",
+
+  "admin.metadata-import.page.error.addFileUrl": "Insert file url first!",
 
   "admin.batch-import.page.error.addFile": "Select Zip file first!",
 


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #1913

## Description
The reason why the build fails is because in the github repo the `ds-file-dropzone-no-uploader` component belongs to the `UploadModule`, while in the internal repo the component is declared in the `SharedModule`, and we have `SharedModule` imported in the `AdminModule`. To fix the build in the github repo we need to import `UploadModule` in the `AdminModule`.

## Instructions for Reviewers

List of changes in this PR:
* Imported UploadModule in AdminModule

**Include guidance for how to test or review your PR.** 
- Check if build is successful.


