### PR TITLE
Fix error message when updating ORCID settings

### DIFF
--- a/src/app/item-page/orcid-page/orcid-sync-settings/orcid-sync-settings.component.ts
+++ b/src/app/item-page/orcid-page/orcid-sync-settings/orcid-sync-settings.component.ts
@@ -156,7 +156,8 @@ export class OrcidSyncSettingsComponent implements OnInit {
         }
       }),
     ).subscribe((remoteData: RemoteData<ResearcherProfile>) => {
-      if (remoteData.isSuccess) {
+      // hasSucceeded is true if the response is success or successStale
+      if (remoteData.hasSucceeded) {
         this.notificationsService.success(this.translateService.get(this.messagePrefix + '.synchronization-settings-update.success'));
         this.settingsUpdated.emit();
       } else {


### PR DESCRIPTION
## References
None

## Description
When a researcher tries to update their ORCID settings, an error message (“The update of the synchronization settings failed”) appears. Indeed REST call returned a 200 response code and settings are actually saved. 

This PR fixes that by changing the response condition from `isSuccess` to `hasSucceeded` as the last one checks for 'success' and 'successStale'.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
