### PR TITLE
entity-dropdown loading authorized import searchlist

### DIFF
--- a/src/app/my-dspace-page/my-dspace-new-submission/my-dspace-new-bulk-import/my-dspace-new-bulk-import.component.html
+++ b/src/app/my-dspace-page/my-dspace-new-submission/my-dspace-new-bulk-import/my-dspace-new-bulk-import.component.html
@@ -22,6 +22,6 @@
          class="dropdown-menu"
          id="entityControlsDropdownMenu"
          aria-labelledby="dropdownSubmission">
-      <ds-entity-dropdown [isSubmission]="false" (selectionChange)="openDialog($event)"></ds-entity-dropdown>
+      <ds-entity-dropdown [isSubmission]="true" (selectionChange)="openDialog($event)"></ds-entity-dropdown>
     </div>
   </div>

--- a/src/app/my-dspace-page/my-dspace-new-submission/my-dspace-new-external-dropdown/my-dspace-new-external-dropdown.component.html
+++ b/src/app/my-dspace-page/my-dspace-new-submission/my-dspace-new-external-dropdown/my-dspace-new-external-dropdown.component.html
@@ -20,6 +20,6 @@
          class="dropdown-menu"
          id="importControlsDropdownMenu"
          aria-labelledby="dropdownImport">
-      <ds-entity-dropdown [isSubmission]="false" (selectionChange)="openPage($event)"></ds-entity-dropdown>
+      <ds-entity-dropdown [isSubmission]="false" [isExternalImport]="true" (selectionChange)="openPage($event)"></ds-entity-dropdown>
     </div>
   </div>


### PR DESCRIPTION
fixes https://github.com/4Science/dspace-angular/issues/14 and removed unused references/imports

## References
* Fixes #14

## Description
- added option to deliver the searchList for all Entities, where the user has the right to Import Entities
## Instructions for Reviewers

List of changes in this PR:
* First: extend entity-dropdown with another Input to mark external Imports. If this input is true, then the regarding method of entityTypeService.`getAllAuthorizedRelationshipTypeImport` is called instead of the default itemExportFormatService method. This additional input is set by the external-import component.
* Second: fix some bug with bulk import loading the wrong list (should load all entities where export format exist)
* Third: removed unsed import and references

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 
- as described in the issue, create some setting where the available item-export formats and the allowed external-sources differs and are not equal. This divergence which was not displayed on the entity-list should have been solved.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [ ] My PR doesn't introduce circular dependencies
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
