### PR TITLE
add missing translation keys

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5237,6 +5237,10 @@
   "statistics.table.mainReports.header.city": "City",
 
   "statistics.table.mainReports.header.item": "Item",
+  
+  "statistics.table.mainReports.header.community": "Community",
+  
+  "statistics.table.mainReports.header.collection": "Collection",
 
   "statistics.table.downloadReports.header.views": "Downloads",
 


### PR DESCRIPTION
Add two missing translation keys `statistics.table.mainReports.header.community` and `statistics.table.mainReports.header.collection`.
