### PR TITLE
remove duplicate keys menu.section.export_batch and nav.subscriptions in i18n resources

### DIFF
--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -6423,10 +6423,6 @@
   // TODO New key - Add a translation
   "menu.section.import_from_excel": "Import from excel",
 
-  // "menu.section.export_batch": "Batch Export (ZIP)",
-  // TODO New key - Add a translation
-  "menu.section.export_batch": "Batch Export (ZIP)",
-
   // "menu.section.export_to_excel": "Export to excel",
   // TODO New key - Add a translation
   "menu.section.export_to_excel": "Export to excel",
@@ -7086,10 +7082,6 @@
   // "nav.user.description" : "User profile bar",
   // TODO New key - Add a translation
   "nav.user.description" : "User profile bar",
-
-  // "nav.subscriptions" : "Subscriptions",
-  // TODO New key - Add a translation
-  "nav.subscriptions" : "Subscriptions",
 
   // "none.listelement.badge": "Item",
   // TODO New key - Add a translation

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3775,8 +3775,6 @@
 
   "menu.section.import_from_excel": "Import from excel",
 
-  "menu.section.export_batch": "Batch Export (ZIP)",
-
   "menu.section.export_to_excel": "Export to excel",
 
   "menu.section.icon.access_control": "Access Control menu section",
@@ -4158,8 +4156,6 @@
   "nav.toggle" : "Toggle navigation",
 
   "nav.user.description" : "User profile bar",
-
-  "nav.subscriptions" : "Subscriptions",
 
   "none.listelement.badge": "Item",
 


### PR DESCRIPTION
## Description

This PR removes two duplicate translation keys in `en.json5` and `de.json5`. The changes need to be applied to the other i18n files.