### PR TITLE
improve handling of orgUnit names: allow to fallback to dc.title

### DIFF
--- a/src/app/core/breadcrumbs/dso-name.service.ts
+++ b/src/app/core/breadcrumbs/dso-name.service.ts
@@ -91,7 +91,11 @@ export class DSONameService {
       }
       return `${familyName}, ${givenName}`;
     } else if (entityType === 'OrgUnit') {
-      return this.firstMetadataValue(object, dso, 'organization.legalName');
+      const orgUnitName = this.firstMetadataValue(object, dso, 'organization.legalName');
+      if (isEmpty(orgUnitName)) {
+        return this.firstMetadataValue(object, dso, 'dc.title') || dso.name;
+      }
+      return orgUnitName;
     }
     return this.firstMetadataValue(object, dso, 'dc.title') || dso.name || this.translateService.instant('dso.name.untitled');
   }


### PR DESCRIPTION
## Description

DSpace CRIS assumes (?) that orgUnit names are stored in `organization.legalName`. If this metadata field is not set the code should fallback to `dc.title` (the same fallback is applied in person name handling).
