### PR TITLE
improve build:ssr by passing max_old_space_size to ng run command

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:stats": "ng build --stats-json",
     "build:ci": "ng config cli.cache.environment ci && yarn run build:ssr",
     "build:prod": "yarn run build:ssr",
-    "build:ssr": "npm run ng-high-memory -- build --configuration production && ng run dspace-angular:server:production",
+    "build:ssr": "npm run ng-high-memory -- build --configuration production && npm run ng-high-memory -- run dspace-angular:server:production",
     "ng-high-memory": "node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng",
     "test": "npm run ng-high-memory -- test --sourceMap=true --watch=false --configuration test",
     "test:watch": "nodemon --exec \"npm run ng-high-memory -- test --sourceMap=true --watch=true --configuration test\"",


### PR DESCRIPTION
This PR extends the heap space adjustment in `build:ssr` to the second `ng run` comannd.

We have seen reproducable out-of-memory error when building the Docker image. The error occurs **after** the successful completion of the first command in `build:ssr` (which is already adjusted in terms of available heap space). 

Output when running `docker build`:

```
251.9 - Generating server application bundles (phase: setup)...
409.6 ✔ Server application bundle generation complete.
421.3
421.3 <--- Last few GCs --->
421.3
421.3 [38:0xffff94cae330]   171120 ms: Mark-sweep (reduce) 1982.9 (2076.8) -> 1982.9 (2075.8) MB, 707.9 / 0.0 ms  (average mu = 0.227, current mu = 0.000) allocation failure; GC in old space requested
421.3 [38:0xffff94cae330]   171706 ms: Mark-sweep (reduce) 1986.2 (2078.5) -> 1983.2 (2078.5) MB, 477.8 / 0.0 ms  (average mu = 0.211, current mu = 0.185) allocation failure; GC in old space requested
421.3
421.3
421.3 <--- JS stacktrace --->
421.3
421.3 FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
421.7 error Command failed with signal "SIGABRT".
421.7 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
422.0 error Command failed with exit code 1.
422.0 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
------
failed to solve: process "/bin/sh -c yarn build:prod" did not complete successfully: exit code: 1
```