### PR TITLE
fix pagination on external sources

### DIFF
--- a/src/app/submission/import-external/submission-import-external.component.ts
+++ b/src/app/submission/import-external/submission-import-external.component.ts
@@ -117,6 +117,7 @@ export class SubmissionImportExternalComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.listId = 'list-submission-external-sources';
     this.context = Context.EntitySearchModalWithNameVariants;
+    this.searchConfigService.setPaginationId(this.initialPagination.id);
     this.repeatable = false;
     this.routeData = {entity: '', sourceId: '', query: ''};
     this.importConfig = {


### PR DESCRIPTION
## References
* Fixes #59 

## Description

Set the paginationId on external sources lists. Otherwise the pagination should not work.

## Instructions for Reviewers
- try to import external sources without this change (it's only one line). By more than 10 entries the pagination should not work
- retry this with the applied patch. The pagination should work

List of changes in this PR:
* add the current calculated uuid of the import-external-component to the searchconfigservice.
* otherwise the searchConfigService should have 'spc' in the configuration. Also see the upstream DSpace paginationID for that: https://github.com/DSpace/dspace-angular/blob/8ba14aa3be56284f020ab50dea0a7bdc22fd2ec5/src/app/submission/import-external/submission-import-external.component.ts#L77
* 
## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [ ] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
