### PR TITLE
Fix two bugs in metadata form handling for updated fields

### DIFF
--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-form.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-form.ts
@@ -439,6 +439,7 @@ export class DsoEditMetadataForm {
                   language: value.newValue.language,
                   authority: value.newValue.authority,
                   confidence: value.newValue.confidence,
+                  securityLevel: value.newValue.securityLevel,
                 }));
               }
               // "replace" the security level value
@@ -448,6 +449,7 @@ export class DsoEditMetadataForm {
                   value: value.newValue.value,
                   language: value.newValue.language,
                   authority: value.newValue.authority,
+                  confidence: value.newValue.confidence,                  
                 }));
               }
             } else if (value.change === DsoEditMetadataChangeType.REMOVE) {


### PR DESCRIPTION
## Description

This PR fixes **two bugs** in metadata form handling.

First Bug: If you change the value of a metadata field that is associated with a security configuration, the current security level is ignored and the security level is set to the default value `null`. In effect, this means that the security level of the metadata field is lost.

Second Bug: If you change the security level of a metadata field, the current confidence value is set to the default value `0`. In effect, this means that the confidence value of the metadata field is lost.



