### PR TITLE
SCSS cleanup: remove duplicated SCSS variables

### DIFF
--- a/src/styles/_custom_variables.scss
+++ b/src/styles/_custom_variables.scss
@@ -190,7 +190,4 @@
   --ds-process-overview-table-user-column-width: 200px;
   --ds-process-overview-table-info-column-width: 250px;
   --ds-process-overview-table-actions-column-width: 80px;
-
-  --green1: #1FB300;  // This variable represents the success color for the Klaro cookie banner
-  --button-text-color-cookie: #333; // This variable represents the text color for buttons in the Klaro cookie banner
 }


### PR DESCRIPTION
## Description

This PR removes two SCSS variables that appear twice in `_custom_variables.scss`.