### PR TITLE
remove console.log in ngOnInit

### DIFF
--- a/src/app/shared/search/search-labels/search-label/search-label.component.ts
+++ b/src/app/shared/search/search-labels/search-label/search-label.component.ts
@@ -48,7 +48,6 @@ export class SearchLabelComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    console.log(this.appliedFilter);
     this.searchLink = this.getSearchLink();
     this.removeParameters$ = this.updateRemoveParams();
   }


### PR DESCRIPTION
## PR Description

This PR removes method call `console.log` in `SearchLabelComponent`.