### PR TITLE
Fix broken read-only form field mechanism in submission forms

### DIFF
--- a/src/app/shared/form/builder/parsers/field-parser.ts
+++ b/src/app/shared/form/builder/parsers/field-parser.ts
@@ -11,14 +11,12 @@ import {
 import { TranslateService } from '@ngx-translate/core';
 import uniqueId from 'lodash/uniqueId';
 
-import {
-  SubmissionVisibilityType,
-  SubmissionVisibilityValue,
-} from '../../../../core/config/models/config-submission-section.model';
+import { SubmissionVisibilityType } from '../../../../core/config/models/config-submission-section.model';
 import { MetadataValue } from '../../../../core/shared/metadata.models';
 import { Metadata } from '../../../../core/shared/metadata.utils';
 import { SubmissionScopeType } from '../../../../core/submission/submission-scope-type';
 import { VocabularyOptions } from '../../../../core/submission/vocabularies/models/vocabulary-options.model';
+import { SubmissionVisibility } from '../../../../submission/utils/visibility.util';
 import { isNgbDateStruct } from '../../../date.util';
 import {
   hasValue,
@@ -372,8 +370,9 @@ export abstract class FieldParser {
   }
 
   /**
-   * Check if a field is read-only with the given scope
+   * Check if a field is read-only within the given scope
    * @param visibility
+   * @param fieldScope
    * @param submissionScope
    */
   private isFieldReadOnly(visibility: SubmissionVisibilityType, fieldScope: string, submissionScope: string) {
@@ -382,12 +381,12 @@ export abstract class FieldParser {
       && isNotEmpty(visibility)
       && ((
         submissionScope === SubmissionScopeType.WorkspaceItem.valueOf()
-          && visibility.main === SubmissionVisibilityValue.ReadOnly
+          && SubmissionVisibility.isReadOnly(visibility, SubmissionScopeType.WorkspaceItem)
       )
         ||
-          (visibility.other === SubmissionVisibilityValue.ReadOnly
-          && submissionScope === SubmissionScopeType.WorkflowItem.valueOf()
-          )
+        (submissionScope === SubmissionScopeType.WorkflowItem.valueOf()
+          && SubmissionVisibility.isReadOnly(visibility, SubmissionScopeType.WorkflowItem)
+        )
       );
   }
 


### PR DESCRIPTION
## References

* Fixes #116 

## Description
The read-only visibility mechanism for submission form fields was not working, as references to SectionVisibility attributes (`main`, `other`) remained after its removal in DSpace CRIS 2024.02.00.

## Instructions for Reviewers
This fix adapts the relevant checks in `field-parser.ts` and adds the missing import required for correct handling of `SubmissionVisibility`.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [ ] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
