### PR TITLE
Remove duplicate data-test attribute from button

### DIFF
--- a/src/app/community-list-page/community-list/community-list.component.html
+++ b/src/app/community-list-page/community-list/community-list.component.html
@@ -27,7 +27,6 @@
       <button *ngIf="hasChild(null, node) | async" type="button" class="btn btn-default" cdkTreeNodeToggle
               [attr.aria-label]="(node.isExpanded ? 'communityList.collapse' : 'communityList.expand') | translate:{ name: dsoNameService.getName(node.payload) }"
               (click)="toggleExpanded(node)"
-              data-test="expand-button"
               (keyup.enter)="toggleExpanded(node)"
               (keyup.space)="toggleExpanded(node)"
               data-test="expand-button"


### PR DESCRIPTION
## Description

This PR makes a minor adjustment to the `community-list.component.html` template by removing a duplicate `data-test` attribute in a `button` element.